### PR TITLE
Fix issues in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,8 @@ RUN apt-get update \
        libtool \
        ca-certificates \
        openssl \
-	   libssl-dev \
-       python3 \ 
+           libssl-dev \
+       python3 \
        python3-pip \
        sudo \
        vim \
@@ -27,23 +27,13 @@ RUN apt-get update \
        libboost-dev \
        libzmq5-dev \
        m4 \
+       cmake \
     #&& sudo /usr/bin/update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc 1 \
     #&& sudo /usr/bin/update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++ 1 \
     #&& sudo sudo /usr/bin/update-alternatives  --set gcc /usr/bin/gcc \
     #&& sudo sudo /usr/bin/update-alternatives  --set g++ /usr/bin/g++ \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /var/cache/apt/archives/*
-
-# Build and install cmake >= 10 
-RUN cd /opt \
-    && wget --no-check-certificate https://github.com/Kitware/CMake/releases/download/v3.20.3/cmake-3.20.3.tar.gz \
-    && tar zxf cmake-3.20.3.tar.gz \
-    && cd cmake-3.20.3 \
-    && ./bootstrap \
-    && make \
-    && make install \
-    && cd \
-    && rm -rf /opt/cmake-3.20.3 cmake-3-20.3.tar.gz
 
 WORKDIR /rd2c
 
@@ -69,8 +59,8 @@ RUN cd ${RD2C} \
     && tar -xzf zeromq-${ZMQ_VERSION}.tar.gz \
     && cd ${RD2C}/zeromq-${ZMQ_VERSION} \
     && ./configure --prefix=${RD2C} \
-    && make \
-    && make install 
+    && make -j$(nproc) \
+    && make install
 
 ENV CFLAGS=-I${RD2C}/include
 ENV LDFLAGS=-L${RD2C}/lib
@@ -81,8 +71,8 @@ RUN cd ${RD2C} \
     && tar -xzf czmq-${CZMQ_VERSION}.tar.gz \
     && cd ${RD2C}/czmq-${CZMQ_VERSION} \
     && ./configure --prefix=${RD2C} \
-    && make \
-    && make install 
+    && make -j$(nproc) \
+    && make install
 
 ENV CLFAGS=
 ENV LDFLAGS=
@@ -96,17 +86,17 @@ ENV PKG_CONFIG_PATH=
 
 
 RUN cd ${RD2C} \
-    && git clone https://github.com/GMLC-TDC/HELICS -b v2.7.1 \ 
+    && git clone https://github.com/GMLC-TDC/HELICS -b v2.7.1 \
     && cd HELICS \
     && mkdir build \
     && cd build \
     && cmake -DHELICS_BUILD_CXX_SHARED_LIB=ON ../ \
-    && make \
-    && make install \ 
+    && make -j$(nproc) \
+    && make install \
     #&& cd /tmp \
-    #&& /bin/rm -r ${TEMP_DIR}/HELICS \ 
+    #&& /bin/rm -r ${TEMP_DIR}/HELICS \
     && pip install helics-apps==2.7.1 \
-    && pip3 install helics-apps==2.7.1 
+    && pip3 install helics-apps==2.7.1
     #&& pip install helics==3.0.0 \
     #&& pip3 install helics==3.0.0 \
     #&& cd ${RD2C}
@@ -115,7 +105,7 @@ RUN cd ${RD2C} \
 #    && pip install --trusted-host=files.pythonhosted.org helics-apps==2.7.1 \
 #    && pip3 install --trusted-host=files.pythonhosted.org helics-apps==2.7.1 \
 #    && pip install --trusted-host=files.pythonhosted.org helics==2.7.1 \
-#    && pip3 install --trusted-host=files.pythonhosted.org helics==2.7.1 
+#    && pip3 install --trusted-host=files.pythonhosted.org helics==2.7.1
 
 # ----------------------------------------------------
 # DOWNLOAD Gridlab-D
@@ -124,12 +114,12 @@ RUN cd ${RD2C} \
 RUN cd ${RD2C} \
    && git clone https://github.com/gridlab-d/gridlab-d.git -b v4.3 --single-branch \
    && cd ${RD2C}/gridlab-d/third_party \
-   && tar -xzf xerces-c-3.2.0.tar.gz 
+   && tar -xzf xerces-c-3.2.0.tar.gz
 
 
 # ----------------------------------------------------
 # INSTALL NS-3
-# ----------------------------------------------------	
+# ----------------------------------------------------
 
 #Download NS3
 RUN cd $RD2C \
@@ -137,7 +127,7 @@ RUN cd $RD2C \
     && mv ns-3-dev-git ns-3-dev \
     && mkdir PUSH \
     && cd PUSH \
-    && git clone https://github.com/pnnl/NATIG.git 
+    && git clone https://github.com/pnnl/NATIG.git
 
 #Update code in NS3 and Gridlabd
 RUN cd $RD2C/PUSH \
@@ -151,30 +141,30 @@ RUN cd $RD2C/PUSH \
     && cp -r RC/code/dnp3/crypto ${RD2C}/ns-3-dev/src/dnp3  \
     && cp -r RC/code/dnp3/dnplib ${RD2C}/ns-3-dev/src/dnp3  \
     && cp -r RC/code/dnp3/examples ${RD2C}/ns-3-dev/src/dnp3 \
-    && cp -r RC/code/dnp3/helper ${RD2C}/ns-3-dev/src/dnp3 \  
-    && mkdir ${RD2C}/ns-3-dev/src/dnp3/model \ 
+    && cp -r RC/code/dnp3/helper ${RD2C}/ns-3-dev/src/dnp3 \
+    && mkdir ${RD2C}/ns-3-dev/src/dnp3/model \
     && cp -r RC/code/dnp3/wscript ${RD2C}/ns-3-dev/src/dnp3/ \
     && cp -r RC/code/dnp3/model/dnp3-application.h ${RD2C}/ns-3-dev/src/dnp3/model/ \
     && cp -r RC/code/dnp3/model/dnp3-application-Docker.cc ${RD2C}/ns-3-dev/src/dnp3/model/dnp3-application.cc \
-    && cp -r RC/code/dnp3/model/dnp3-application-Docker.cc ${RD2C}/ns-3-dev/src/dnp3/model/dnp3-application.cc \    
+    && cp -r RC/code/dnp3/model/dnp3-application-Docker.cc ${RD2C}/ns-3-dev/src/dnp3/model/dnp3-application.cc \
     && cp -r RC/code/dnp3/model/dnp3-simulator-impl.* ${RD2C}/ns-3-dev/src/dnp3/model/ \
     && cp -r RC/code/dnp3/model/tcptest* ${RD2C}/ns-3-dev/src/dnp3/model/ \
-    && cp -r RC/code/dnp3/model/dnp3-mim-* ${RD2C}/ns-3-dev/src/dnp3/model/ \  
+    && cp -r RC/code/dnp3/model/dnp3-mim-* ${RD2C}/ns-3-dev/src/dnp3/model/ \
     #&& cp -r RC/code/applications/model/fncs-application.* ${RD2C}/ns-3-dev/src/applications/model/ \
     && cp -r RC/code/internet/* ${RD2C}/ns-3-dev/src/internet/ \
     && cp -r RC/code/lte/* ${RD2C}/ns-3-dev/src/lte/ \
     && cp -r RC/code/gridlabd/* ${RD2C}/gridlab-d/tape_file/ \
-    && cp -r RC/code/trigger.player ${RD2C}/integration/control/ 
+    && cp -r RC/code/trigger.player ${RD2C}/integration/control/
 
 # Install Gridlabd
 RUN cd ${RD2C}/gridlab-d/third_party/xerces-c-3.2.0 \
    && ./configure \
-   && make \
+   && make -j$(nproc) \
    && make install \
    && cd ${RD2C}/gridlab-d \
    && autoreconf -if \
    && ./configure --with-helics=/usr/local --prefix=$GLD_INSTALL --enable-silent-rules 'CFLAGS=-g -O2 -w' 'CXXFLAGS=-g -O2 -w -std=c++14' 'LDFLAGS=-g -O2 -w' \
-   && make \
+   && make -j$(nproc) \
    && make install
 
 RUN apt-get update && apt-get install -y libjsoncpp-dev
@@ -186,7 +176,7 @@ RUN apt-get install -y openmpi-bin openmpi-common libopenmpi-dev libgtk2.0-dev
 #Finish installing NS3
 ENV LDFLAGS="-ljsoncpp -L/usr/local/include/jsoncpp/"
 RUN cd $RD2C/PUSH/NATIG \
-    && ./build_ns3.sh "" ${RD2C} 
+    && ./build_ns3.sh "" ${RD2C}
 
 RUN apt-get update && apt-get install -y procps
 
@@ -204,13 +194,13 @@ RUN apt update \
      && apt-get clean
 
 # ----------------------------------------------------
-# Set the JAVA_HOME variable 
+# Set the JAVA_HOME variable
 # ----------------------------------------------------
 
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
 
 # ----------------------------------------------------
-# Copy model files 
+# Copy model files
 # ----------------------------------------------------
 
 ADD input $RD2C/input

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,23 +33,6 @@ RUN apt-get update \
     #&& sudo sudo /usr/bin/update-alternatives  --set g++ /usr/bin/g++ \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /var/cache/apt/archives/*
-	
-# Build and install gcc 8
-RUN cd /opt \
-    && wget http://ftp.mirrorservice.org/sites/sourceware.org/pub/gcc/releases/gcc-8.4.0/gcc-8.4.0.tar.gz \
-    && tar zxf gcc-8.4.0.tar.gz \
-    && cd gcc-8.4.0 \
-    && ./contrib/download_prerequisites \
-    && apt -y install build-essential \
-    && ./configure --disable-multilib \
-    && make -j 4 \
-    && make install \
-    && cd \
-    && rm -rf /opt/gcc-8.4.0 /opt/gcc-8.4.0.tar.gz \
-    && sudo /usr/bin/update-alternatives --install /usr/bin/gcc gcc /usr/local/bin/gcc 1 \
-    && sudo /usr/bin/update-alternatives --install /usr/bin/g++ g++ /usr/local/bin/g++ 1 \
-    && sudo sudo /usr/bin/update-alternatives  --set gcc /usr/local/bin/gcc \
-    && sudo sudo /usr/bin/update-alternatives  --set g++ /usr/local/bin/g++
 
 # Build and install cmake >= 10 
 RUN cd /opt \


### PR DESCRIPTION
The following changes allowed the Docker image to build in my VM and reduced image build time from 246 minutes to 44 minutes.
- Fix FTP networking issues by removing section that redundantly compiles GCC
- Install CMake with apt instead of compiling
- Multithread compilation with make flag `-j$(nproc)`